### PR TITLE
New signatures fixes (for review only)

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   federation:
-    image: sovryn/fed-tokenbridge:10.12
+    image: sovryn/fed-tokenbridge:10.13
     ports:
       - 30303:30303
     volumes:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   federation:
-    image: sovryn/fed-tokenbridge:10.11
+    image: sovryn/fed-tokenbridge:10.12
     ports:
       - 30303:30303
     volumes:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   federation:
-    image: sovryn/fed-tokenbridge:10.10
+    image: sovryn/fed-tokenbridge:10.11
     ports:
       - 30303:30303
     volumes:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   federation:
-    image: sovryn/fed-tokenbridge:10.9
+    image: sovryn/fed-tokenbridge:10.10
     ports:
       - 30303:30303
     volumes:

--- a/federator-env/testnet-ETH-RSK/config.js
+++ b/federator-env/testnet-ETH-RSK/config.js
@@ -29,7 +29,7 @@ module.exports = {
     runEvery: 2, // In minutes,
     confirmations: 120, // Number of blocks before processing it, if working with ganache set as 0
     privateKey: fs.readFileSync(`${__dirname}/federator.key`, 'utf8').trim(),
-    signaturesTTL: 120,
+    signaturesTTL: 24 * 60 * 60, // In seconds
     storagePath: './db',
     federatorInstanceId: 'federatorInstanceId_replace_this',
     federatorAddress: 'federatorAddress_replace_this',

--- a/federator-env/testnet-ETH-RSK/config.js
+++ b/federator-env/testnet-ETH-RSK/config.js
@@ -30,6 +30,7 @@ module.exports = {
     confirmations: 120, // Number of blocks before processing it, if working with ganache set as 0
     privateKey: fs.readFileSync(`${__dirname}/federator.key`, 'utf8').trim(),
     signaturesTTL: 24 * 60 * 60, // In seconds
+    signatureRequestTimeoutMs: 2 * 60 * 1000, // In milliseconds
     storagePath: './db',
     federatorInstanceId: 'federatorInstanceId_replace_this',
     federatorAddress: 'federatorAddress_replace_this',

--- a/federator-env/testnet-ETH-RSK/ropsten.json
+++ b/federator-env/testnet-ETH-RSK/ropsten.json
@@ -5,5 +5,5 @@
     "allowTokens": "0x9bc4243880730a9bca69addb0f971700d39d1646",
     "erc777Converter": "0x8F3bbD7673485Cf4c43EF008e125575028fD43F1",
     "host": "https://ropsten.infura.io/v3/728946296ea64626941bb3d120d16333",
-    "fromBlock": 10281973
+    "fromBlock": 12190673
 }

--- a/federator-env/testnet-ETH-RSK/ropsten.json
+++ b/federator-env/testnet-ETH-RSK/ropsten.json
@@ -5,5 +5,5 @@
     "allowTokens": "0x9bc4243880730a9bca69addb0f971700d39d1646",
     "erc777Converter": "0x8F3bbD7673485Cf4c43EF008e125575028fD43F1",
     "host": "https://ropsten.infura.io/v3/728946296ea64626941bb3d120d16333",
-    "fromBlock": 10222073
+    "fromBlock": 10281973
 }

--- a/federator-env/testnet-ETH-RSK/rsktestnet.json
+++ b/federator-env/testnet-ETH-RSK/rsktestnet.json
@@ -5,5 +5,5 @@
     "allowTokens": "0x918b9fd8c2e9cf5625ea00ca6cfa270a44050d01",
     "erc777Converter": "0x621d9Ce70Db000273Ddb3d50fa85732960a9E934",
     "host": "https://testnet2.sovryn.app/rpc",
-    "fromBlock": 1980020
+    "fromBlock": 2960023
 }

--- a/federator-env/testnet-ETH-RSK/rsktestnet.json
+++ b/federator-env/testnet-ETH-RSK/rsktestnet.json
@@ -5,5 +5,5 @@
     "allowTokens": "0x918b9fd8c2e9cf5625ea00ca6cfa270a44050d01",
     "erc777Converter": "0x621d9Ce70Db000273Ddb3d50fa85732960a9E934",
     "host": "https://testnet2.sovryn.app/rpc",
-    "fromBlock": 2960023
+    "fromBlock": 2962423
 }

--- a/how_to_build_fed_docker_image.md
+++ b/how_to_build_fed_docker_image.md
@@ -5,7 +5,7 @@ with github actions
 
 * create tag: ```git tag 8.5```
 
-* push tag: ```git push 8.5```
+* push tag: ```git push origin 8.5```
 
 
 

--- a/how_to_build_fed_docker_image.md
+++ b/how_to_build_fed_docker_image.md
@@ -5,7 +5,7 @@ with github actions
 
 * create tag: ```git tag 8.5```
 
-* push tags: ```git push tag 8.5```
+* push tag: ```git push 8.5```
 
 
 

--- a/sovryn-token-bridge/federator/config/config.sample.js
+++ b/sovryn-token-bridge/federator/config/config.sample.js
@@ -24,7 +24,7 @@ module.exports = {
     runEvery: 2, // In minutes,
     confirmations: 120, // Number of blocks before processing it, if working with ganache set as 0
     privateKey: fs.readFileSync(`${__dirname}/federator.key`, 'utf8').trim(),
-    signaturesTTL: 120, // 2 minutes
+    signaturesTTL: 24 * 60 * 60, // In seconds
     storagePath: './db',
     federatorInstanceId: '',
     etherscanApiKey: etherscanApiKey,

--- a/sovryn-token-bridge/federator/src/lib/Federator.js
+++ b/sovryn-token-bridge/federator/src/lib/Federator.js
@@ -208,13 +208,6 @@ module.exports = class Federator {
 
             const signatures = new Set();
             const listener = this.network.net.onMessage(async (msg) => {
-                // TODO: temporary logging, remove
-                this.logger.debug('got federator message');
-                console.log(msg.type)
-                console.log(msg.data)
-                console.log('msg.type === submissionType?', msg.type === submissionType)
-                console.log('msg.data.logId === log.id?', msg.data.logId === log.id, msg.data.logId, log.id);
-
                 if (msg.type === submissionType && msg.data.logId === log.id) {
                     this.logger.info(`Submission received from ${msg.source.id}`);
 

--- a/sovryn-token-bridge/federator/src/lib/Federator.js
+++ b/sovryn-token-bridge/federator/src/lib/Federator.js
@@ -181,7 +181,10 @@ module.exports = class Federator {
             this.logger.info('Requesting other federators to sign event');
 
             const timer = setTimeout(
-                () => reject("Didn't get enough signatures after 10 minutes timeout"),
+                () => {
+                    this.logger.warn("Timeout: Didn't get enough signatures after waiting");
+                    reject("Didn't get enough signatures after 10 minutes timeout")
+                },
                 60000
             );
 
@@ -198,7 +201,15 @@ module.exports = class Federator {
                       };
 
             const signatures = new Set();
+            // TODO: this listener should be removed on timeout
             const listener = this.network.net.onMessage(async (msg) => {
+                // TODO: temporary logging, remove
+                this.logger.debug('got federator message');
+                console.log(msg.type)
+                console.log(msg.data)
+                console.log('msg.type === submissionType?', msg.type === submissionType)
+                console.log('msg.data.logId === log.id?', msg.data.logId === log.id, msg.data.logId, log.id);
+
                 if (msg.type === submissionType && msg.data.logId === log.id) {
                     this.logger.info(`Submission received from ${msg.source.id}`);
 

--- a/sovryn-token-bridge/federator/src/lib/Federator.js
+++ b/sovryn-token-bridge/federator/src/lib/Federator.js
@@ -230,6 +230,13 @@ module.exports = class Federator {
                     }
                     signers.add(signerAddress);
 
+                    if (!utils.validateDeadline(signatureData.deadline)) {
+                        this.logger.warn(
+                            `Deadline ${signatureData.deadline} has either passed or is too close`
+                        );
+                        return;
+                    }
+
                     signatures.add(signatureData);
                     if (signatures.size >= this.config.minimumPeerAmount) {
                         clearTimeout(timer);

--- a/sovryn-token-bridge/federator/src/lib/Federator.js
+++ b/sovryn-token-bridge/federator/src/lib/Federator.js
@@ -207,6 +207,7 @@ module.exports = class Federator {
                       };
 
             const signatures = new Set();
+            const signers = new Set();
             const listener = this.network.net.onMessage(async (msg) => {
                 if (msg.type === submissionType && msg.data.logId === log.id) {
                     this.logger.info(`Submission received from ${msg.source.id}`);
@@ -220,6 +221,14 @@ module.exports = class Federator {
                         );
                         return;
                     }
+
+                    if (signers.has(signerAddress)) {
+                        this.logger.warn(
+                            `Signer ${signerAddress} has already submitted a signature`
+                        );
+                        return;
+                    }
+                    signers.add(signerAddress);
 
                     signatures.add(signatureData);
                     if (signatures.size >= this.config.minimumPeerAmount) {

--- a/sovryn-token-bridge/federator/src/lib/Federator.js
+++ b/sovryn-token-bridge/federator/src/lib/Federator.js
@@ -189,9 +189,9 @@ module.exports = class Federator {
                     } catch(e) {
                         this.logger.error(`Error subscribing from listener on timeout: ${e}`);
                     }
-                    reject("Didn't get enough signatures after 10 minutes timeout")
+                    reject("Didn't get enough signatures before timeout")
                 },
-                60000
+                this.config.signatureRequestTimeoutMs || 60000
             );
 
             // Select correct message type depending on main on side federator

--- a/sovryn-token-bridge/federator/src/lib/Federator.js
+++ b/sovryn-token-bridge/federator/src/lib/Federator.js
@@ -184,6 +184,11 @@ module.exports = class Federator {
             const timer = setTimeout(
                 () => {
                     this.logger.warn("Timeout: Didn't get enough signatures after waiting");
+                    try {
+                        listener.unsubscribe();
+                    } catch(e) {
+                        this.logger.error(`Error subscribing from listener on timeout: ${e}`);
+                    }
                     reject("Didn't get enough signatures after 10 minutes timeout")
                 },
                 60000
@@ -202,7 +207,6 @@ module.exports = class Federator {
                       };
 
             const signatures = new Set();
-            // TODO: this listener should be removed on timeout
             const listener = this.network.net.onMessage(async (msg) => {
                 // TODO: temporary logging, remove
                 this.logger.debug('got federator message');

--- a/sovryn-token-bridge/federator/src/lib/Federator.js
+++ b/sovryn-token-bridge/federator/src/lib/Federator.js
@@ -564,11 +564,12 @@ module.exports = class Federator {
     }
 
     async signTransaction({ blockNumber, id }) {
-        const logs = await this.mainBridgeContract.getPastEvents('Cross', {
+        const allLogs = await this.mainBridgeContract.getPastEvents('Cross', {
             fromBlock: blockNumber,
             toBlock: blockNumber,
-            filter: { id },
         });
+        // Passing filter: { id } to getPastEvents won't do any filtering, we need to filter like this
+        const logs = allLogs.filter(log => log.id === id);
 
         if (logs.length !== 1) {
             this.logger.error(`Got ${logs.length} logs when expecting 1. Block number: ${blockNumber}, Log id: ${id}, Logs:`);

--- a/sovryn-token-bridge/federator/src/lib/Federator.js
+++ b/sovryn-token-bridge/federator/src/lib/Federator.js
@@ -145,12 +145,6 @@ module.exports = class Federator {
     // Loop around logs to process each of them
     async _processLogs(ctr, logs) {
         try {
-            const transactionSender = new TransactionSender(
-                this.sideWeb3,
-                this.logger,
-                this.config,
-                ''
-            );
             const currentBlock = await this._getCurrentBlockNumber();
 
             let newLastBlockNumber;

--- a/sovryn-token-bridge/federator/src/lib/Federator.js
+++ b/sovryn-token-bridge/federator/src/lib/Federator.js
@@ -570,7 +570,11 @@ module.exports = class Federator {
             filter: { id },
         });
 
-        if (logs.length !== 1) throw new CustomError('Invalid return when searching for event');
+        if (logs.length !== 1) {
+            this.logger.error(`Got ${logs.length} logs when expecting 1. Block number: ${blockNumber}, Log id: ${id}, Logs:`);
+            this.logger.error(logs);
+            throw new CustomError('Invalid return when searching for event');
+        }
 
         const { _tokenAddress, _amount, _to, _symbol, _decimals, _granularity, _userData } =
             logs[0].returnValues;

--- a/sovryn-token-bridge/federator/src/lib/Federator.js
+++ b/sovryn-token-bridge/federator/src/lib/Federator.js
@@ -230,7 +230,14 @@ module.exports = class Federator {
                     }
                     signers.add(signerAddress);
 
-                    if (!utils.validateDeadline(signatureData.deadline)) {
+                    // Require 2 minutes or signaturesTTL/2 of buffer, whichever is smaller, to avoid sending the
+                    // transactions with signatures that might expire before the transaction gets mined in the blockchain.
+                    // 2 minutes might not be enough, but we need to start with something
+                    const deadlineBufferSeconds = Math.min(
+                        this.config.signaturesTTL / 2,
+                        120
+                    );
+                    if (!utils.validateDeadline(signatureData.deadline, deadlineBufferSeconds)) {
                         this.logger.warn(
                             `Deadline ${signatureData.deadline} has either passed or is too close`
                         );

--- a/sovryn-token-bridge/federator/src/lib/utils.js
+++ b/sovryn-token-bridge/federator/src/lib/utils.js
@@ -126,8 +126,13 @@ function eliminateDuplicates(arrays) {
     return Array.from(set);
 }
 
-function createTimestamp(secondesOffset) {
-    return Math.floor(Date.now() / 1000) + secondesOffset;
+function createTimestamp(secondsOffset) {
+    return Math.floor(Date.now() / 1000) + secondsOffset;
+}
+
+function validateDeadline(deadline, bufferSeconds = 0) {
+    const currentTimestamp = Math.floor(Date.now() / 1000);
+    return deadline >= currentTimestamp + bufferSeconds;
 }
 
 module.exports = {
@@ -143,5 +148,6 @@ module.exports = {
     zeroHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
     waitForReceipt: waitForReceipt,
     eliminateDuplicates: eliminateDuplicates,
-    createTimestamp: createTimestamp,
+    createTimestamp,
+    validateDeadline,
 };

--- a/sovryn-token-bridge/federator/src/main.js
+++ b/sovryn-token-bridge/federator/src/main.js
@@ -195,6 +195,7 @@ async function run() {
     }
 
     if (p2pNode.isLeader()) {
+        console.log("This node is a leader -- handling iteration.")
         try {
             console.log('before mainfed');
             await mainFederator.run();
@@ -204,6 +205,8 @@ async function run() {
             logger.error('Unhandled Error on run()', err);
             process.exit();
         }
+    } else {
+        console.log("Not leader, just chilling.")
     }
 }
 

--- a/sovryn-token-bridge/federator/test/Federator.test.js
+++ b/sovryn-token-bridge/federator/test/Federator.test.js
@@ -482,8 +482,29 @@ describe('Federator module tests', () => {
     describe('Signatures', () => {
         const chainId = 1;
         const contractAddress = testConfig.sidechain.federation;
-        const wallets = [];
+        const txId = '0x7cfbaa6f05794922229e60c7c9695cc52cd13ed9ab1b88597626bd70bb8315d1';
+        const wallets = [
+            new ethers.Wallet(testConfig.privateKey),
+            new ethers.Wallet(
+                '0x20a3c8eb679bc7fe83e31754871c31a0cff0bf8d96edb8136f1b364753f720f1'
+            ),
+            new ethers.Wallet(
+                '0x6ff46791d809f5a588c1339dc065e38d2079eafa6ff32130a6d5686e0b6b60ea'
+            ),
+        ];
         const signatures = [];
+
+        const createSignature = async (wallet, deadline) => {
+            const payload = ethers.utils.solidityPack(
+                ['bytes32', 'uint256', 'address', 'uint256'],
+                [txId, chainId, contractAddress, deadline]
+            );
+            const signature = await wallet.signMessage(ethers.utils.arrayify(payload));
+            return {
+                signature,
+                deadline,
+            }
+        }
 
         const logs = [
             {
@@ -555,31 +576,9 @@ describe('Federator module tests', () => {
         ];
 
         beforeAll(async () => {
-            wallets.push(new ethers.Wallet(testConfig.privateKey));
-            wallets.push(
-                new ethers.Wallet(
-                    '0x20a3c8eb679bc7fe83e31754871c31a0cff0bf8d96edb8136f1b364753f720f1'
-                )
-            );
-            wallets.push(
-                new ethers.Wallet(
-                    '0x6ff46791d809f5a588c1339dc065e38d2079eafa6ff32130a6d5686e0b6b60ea'
-                )
-            );
-
-            const txId = '0x7cfbaa6f05794922229e60c7c9695cc52cd13ed9ab1b88597626bd70bb8315d1';
-
             const deadline = Math.floor(Date.now() / 1000) + 120;
-            const payload = ethers.utils.solidityPack(
-                ['bytes32', 'uint256', 'address', 'uint256'],
-                [txId, chainId, contractAddress, deadline]
-            );
             for (let i = 0; i < wallets.length; i += 1) {
-                const signature = await wallets[i].signMessage(ethers.utils.arrayify(payload));
-                signatures.push({
-                    signature,
-                    deadline,
-                });
+                signatures.push(await createSignature(wallets[i], deadline));
             }
         });
 

--- a/sovryn-token-bridge/federator/test/Federator.test.js
+++ b/sovryn-token-bridge/federator/test/Federator.test.js
@@ -876,6 +876,49 @@ describe('Federator module tests', () => {
             expect(res[1]).toBe(signatures[2]);
         });
 
+        it("should not use signature if the deadline is too close", async () => {
+            const signatureWithTooCloseDL = await createSignature(
+                wallets[1],
+                utils.createTimestamp(59),  // it should require 60s buffer because signaturesTTL is 120
+            );
+            const mockP2p = {
+                net: {
+                    onMessage: (func) => {
+                        this.callback = func;
+                        return { unsubscribe: () => {} };
+                    },
+                    broadcast: (_, { log }) => {
+                        this.callback({
+                            type: MAIN_SIGNATURE_SUBMISSION,
+                            source: { id: 'TEST-ID' },
+                            data: { signatureData: signatures[0], logId: log.id },
+                        });
+                        this.callback({
+                            type: MAIN_SIGNATURE_SUBMISSION,
+                            source: { id: 'TEST-ID' },
+                            data: {
+                                signatureData: signatureWithTooCloseDL,
+                                logId: log.id
+                            },
+                        });
+                        this.callback({
+                            type: MAIN_SIGNATURE_SUBMISSION,
+                            source: { id: 'TEST-ID' },
+                            data: { signatureData: signatures[2], logId: log.id },
+                        });
+                    },
+                },
+            };
+
+            const federator = createFederator(mockP2p, [wallets[0].address, wallets[1].address, wallets[2].address]);
+
+            const res = await federator._requestSignatureFromFederators(logs[0]);
+            expect(res).toHaveLength(2);
+            expect(res[0]).toBe(signatures[0]);
+            // if res[1] is signatureWithLateDL, the test fails
+            expect(res[1]).toBe(signatures[2]);
+        });
+
         it('should not use signature if not from federator', async () => {
             const mockP2p = {
                 net: {

--- a/sovryn-token-bridge/federator/test/Federator.test.js
+++ b/sovryn-token-bridge/federator/test/Federator.test.js
@@ -686,6 +686,48 @@ describe('Federator module tests', () => {
             expect(res[1]).toBe(signatures[2]);
         });
 
+        it("should not use signature if the deadline does not match", async () => {
+            const mockP2p = {
+                net: {
+                    onMessage: (func) => {
+                        this.callback = func;
+                        return { unsubscribe: () => {} };
+                    },
+                    broadcast: (_, { log }) => {
+                        this.callback({
+                            type: MAIN_SIGNATURE_SUBMISSION,
+                            source: { id: 'TEST-ID' },
+                            data: { signatureData: signatures[0], logId: log.id },
+                        });
+                        this.callback({
+                            type: MAIN_SIGNATURE_SUBMISSION,
+                            source: { id: 'TEST-ID' },
+                            data: {
+                                signatureData: {
+                                    ...signatures[1],
+                                    deadline: signatures[1].deadline + 1,
+                                },
+                                logId: log.id
+                            },
+                        });
+                        this.callback({
+                            type: MAIN_SIGNATURE_SUBMISSION,
+                            source: { id: 'TEST-ID' },
+                            data: { signatureData: signatures[2], logId: log.id },
+                        });
+                    },
+                },
+            };
+
+            const federator = new Federator(MAIN_FEDERATOR, testConfig, logger, mockP2p, web3Mock);
+            federator.members = [wallets[0].address, wallets[1].address, wallets[2].address];
+
+            const res = await federator._requestSignatureFromFederators(logs[0]);
+            expect(res).toHaveLength(2);
+            expect(res[0]).toBe(signatures[0]);
+            expect(res[1]).toBe(signatures[2]);
+        });
+
         it('should not use signature if not from federator', async () => {
             const mockP2p = {
                 net: {

--- a/sovryn-token-bridge/federator/test/config.json
+++ b/sovryn-token-bridge/federator/test/config.json
@@ -21,6 +21,7 @@
     "port": 30303,
     "runEvery": 1,
     "signaturesTTL": 120,
+    "signatureRequestTimeoutMs": 100,
     "sleepOnGas": 2,
     "maxSleepOnGas": 3,
     "confirmations": 0,


### PR DESCRIPTION
This PR includes the new fixes added by me to the signatures branch:

- ﻿﻿Increased signatures TTL to 24h (2min is not enough, especially for ethereum)
- Fixed federator listener leak on timeout in `_requestSignaturesFromFederators`
- Added validation for signature deadlines
- Added validation so one federator cannot sign multiple times (even if the signatures differ)
- Improved federator tests
- Fixed running single test a time by removing global state mutation from tests ﻿(This prevented running single test with `it.only` or `jest -t` and was generally ugly. Tests should always work in isolation)
- General refactoring and code quality improvements.